### PR TITLE
feat: add iterm2 script and xmls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "one-hunter",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "one-hunter",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "@types/vscode": "^1.74.0"
       },
@@ -14,7 +14,8 @@
         "@types/node": "^18.11.18",
         "ts-node": "^10.9.1",
         "tslib": "^2.4.1",
-        "typescript": "^4.9.4"
+        "typescript": "^4.9.4",
+        "xmlbuilder": "^15.1.1"
       },
       "engines": {
         "vscode": "^1.70.0"
@@ -208,6 +209,15 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
@@ -358,6 +368,12 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
+    },
+    "xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
       "dev": true
     },
     "yn": {

--- a/package.json
+++ b/package.json
@@ -77,9 +77,11 @@
     "url": "https://github.com/Railly/one-hunter-vscode.git"
   },
   "scripts": {
-    "generate": "tsc ./scripts/generate-theme.ts && node ./dist/generate-theme.js",
+    "generate:vscode": "ts-node --project scripts/tsconfig.json scripts/generate-theme.ts",
+    "generate:iterm2": "ts-node --project scripts/tsconfig.json scripts/generate-iterm2-theme.ts",
+    "generate": "npm run generate:vscode && npm run generate:iterm2",
     "build:ts": "tsc -p src",
-    "build:theme": "ts-node --project scripts/tsconfig.json scripts/generate-theme.ts",
+    "build:theme": "npm run generate",
     "build": "npm run build:ts && npm run build:theme",
     "publish": "vsce publish",
     "package": "vsce package"

--- a/scripts/generate-iterm2-theme.ts
+++ b/scripts/generate-iterm2-theme.ts
@@ -1,0 +1,95 @@
+import { Theme } from "../src/Theme/index";
+import * as defaultConfig from "../src/Theme/config/defaultConfig.json";
+import * as materialConfig from "../src/Theme/config/materialConfig.json";
+import * as vercelConfig from "../src/Theme/config/vercelConfig.json";
+import * as lightConfig from "../src/Theme/config/lightConfig.json";
+import { promises as fs } from "fs";
+import xmlbuilder from "xmlbuilder";
+import { dirname, resolve } from "path";
+import themeData, { OneHunterColors } from "../src/themes";
+
+function convertToRGB(color: string): { r: number; g: number; b: number } {
+  const hex = color.substring(1); // remove #
+  const r = parseInt(hex.substring(0, 2), 16) / 255;
+  const g = parseInt(hex.substring(2, 4), 16) / 255;
+  const b = parseInt(hex.substring(4, 6), 16) / 255;
+  return { r, g, b };
+}
+
+function createIterm2Theme(variant: string, theme: Theme) {
+  const root = xmlbuilder.create("plist").att("version", "1.0").ele("dict");
+  const colorObj = themeData.textColors[variant] as Record<
+    keyof typeof OneHunterColors,
+    string
+  >;
+
+  const foregroundColor = variant === "light" ? colorObj.alto : colorObj.white;
+  const backgroundColor = colorObj.shark;
+  const ansi7Color = variant === "light" ? colorObj.gray : "#ffffff";
+  const ansi15Color = variant === "light" ? "#ffffff" : colorObj.white;
+
+  const colorMap = new Map([
+    [[backgroundColor], ["Background Color"]],
+    [[foregroundColor], ["Foreground Color"]],
+    [[ansi15Color], ["Ansi 15 Color"]],
+    [[colorObj.gray], ["Ansi 8 Color"]],
+    [[colorObj.frenchRose], ["Ansi 1 Color", "Ansi 9 Color"]],
+    [[colorObj.turquoise], ["Ansi 2 Color", "Ansi 10 Color"]],
+    [[colorObj.saffronMango], ["Ansi 3 Color", "Ansi 11 Color"]],
+    [[colorObj.cornflowerBlue], ["Ansi 4 Color", "Ansi 12 Color"]],
+    [[colorObj.heliotrope], ["Ansi 5 Color", "Ansi 13 Color"]],
+    [[colorObj.dodgeBlue], ["Ansi 6 Color", "Ansi 14 Color"]],
+    [[ansi7Color], ["Ansi 7 Color"]],
+    [["#000000"], ["Ansi 0 Color"]],
+  ]);
+
+  colorMap.forEach((colorKeys, color) => {
+    const { r, g, b } = convertToRGB(color[0]);
+    colorKeys.forEach((colorKey) => {
+      const colorDict = root.ele("key", colorKey).up().ele("dict");
+      colorDict.ele("key", "Color Space").up().ele("string", "sRGB").up();
+      colorDict.ele("key", "Red Component").up().ele("real", r).up();
+      colorDict.ele("key", "Green Component").up().ele("real", g).up();
+      colorDict.ele("key", "Blue Component").up().ele("real", b).up();
+    });
+  });
+
+  return root.end({ pretty: true });
+}
+async function ensureDirectoryExists(filePath: string) {
+  const dir = dirname(filePath);
+  try {
+    await fs.access(dir);
+  } catch {
+    await fs.mkdir(dir, { recursive: true });
+  }
+}
+
+async function writeXMLFile(path: string, data: string): Promise<void> {
+  return fs.writeFile(resolve(path), data);
+}
+
+async function generateIterm2Themes() {
+  const themes = {
+    "OneHunter-Classic": Theme.init(defaultConfig),
+    "OneHunter-Material": Theme.init(materialConfig),
+    "OneHunter-Vercel": Theme.init(vercelConfig),
+    "OneHunter-Light": Theme.init(lightConfig),
+  };
+
+  const themeVariantNames = {
+    "OneHunter-Classic": "classic",
+    "OneHunter-Material": "material",
+    "OneHunter-Vercel": "vercel",
+    "OneHunter-Light": "light",
+  };
+
+  for (const [name, theme] of Object.entries(themes)) {
+    const filePath = `./themes/iterm2/${name}.itermcolors.xml`;
+    await ensureDirectoryExists(filePath);
+    const xml = createIterm2Theme(themeVariantNames[name], theme);
+    await writeXMLFile(filePath, xml);
+  }
+}
+
+generateIterm2Themes();

--- a/scripts/generate-theme.ts
+++ b/scripts/generate-theme.ts
@@ -13,22 +13,22 @@ export function writeFile(path: string, data: unknown): Promise<void> {
 async function generateTheme() {
   writeFile(
     join(__dirname, "..", "themes", "OneHunter-Classic-color-theme.json"),
-    await Theme.init(defaultConfig)
+    Theme.init(defaultConfig)
   );
 
   writeFile(
     join(__dirname, "..", "themes", "OneHunter-Material-color-theme.json"),
-    await Theme.init(materialConfig)
+    Theme.init(materialConfig)
   );
 
   writeFile(
     join(__dirname, "..", "themes", "OneHunter-Vercel-color-theme.json"),
-    await Theme.init(vercelConfig)
+    Theme.init(vercelConfig)
   );
 
   writeFile(
     join(__dirname, "..", "themes", "OneHunter-Light-color-theme.json"),
-    await Theme.init(lightConfig)
+    Theme.init(lightConfig)
   );
 }
 

--- a/src/Theme/index.ts
+++ b/src/Theme/index.ts
@@ -13,10 +13,7 @@ export class Theme {
     this.tokenColors = themeTokens.tokenColors;
   }
 
-  static async init(config: ThemeConfiguration) {
-    const result = {
-      ...new Theme(config),
-    };
-    return result;
+  static init(config: ThemeConfiguration): Theme {
+    return new Theme(config);
   }
 }

--- a/src/Theme/types.ts
+++ b/src/Theme/types.ts
@@ -1,3 +1,5 @@
+import { OneHunterColors } from "../themes";
+
 export interface TokenColor {
   name?: string;
   scope: string | string[];
@@ -10,4 +12,12 @@ export interface TokenColor {
 export interface ThemeConfiguration {
   editorTheme: string;
   variant: string;
+}
+
+export interface ThemeEntity {
+  name: string;
+  variant: string;
+  type: string;
+  colors: Record<string, string>;
+  tokenColors: any;
 }

--- a/src/Theme/utils.ts
+++ b/src/Theme/utils.ts
@@ -2,7 +2,7 @@ import { ThemeConfiguration, TokenColor } from "./types";
 import themeData from "../themes";
 
 export function configFactory(configuration: ThemeConfiguration) {
-  const rawEditorColors: typeof themeData.editorThemes["one-hunter"] =
+  const rawEditorColors: (typeof themeData.editorThemes)["one-hunter"] =
     JSON.parse(
       JSON.stringify(themeData.editorThemes[configuration.editorTheme])
     );

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -4,6 +4,6 @@ import { Theme } from "./Theme/index";
 
 export const generateTheme = {
   default: async function () {
-    return await Theme.init(defaultSettings);
+    return Theme.init(defaultSettings);
   },
 };

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -1,4 +1,4 @@
-enum OneHunterColors {
+export enum OneHunterColors {
   white = "white",
   black0 = "black0",
   black1 = "black1",
@@ -1103,70 +1103,63 @@ export default {
       {
         scope: [
           "keyword.other.declaration-specifier.swift",
-          "keyword.other.declaration-specifier.accessibility.swift"
+          "keyword.other.declaration-specifier.accessibility.swift",
         ],
         settings: {
           foreground: OneHunterColors.frenchRose,
-          fontStyle: OneHunterColors["keyword-weight"]
-        }
+          fontStyle: OneHunterColors["keyword-weight"],
+        },
       },
       {
         scope: [
           "support.type.swift",
           "meta.function-result.swift",
           "variable.language.swift",
-          "keyword.operator.custom.infix.swift"
-        ],
-        settings: {
-          foreground: OneHunterColors.cornflowerBlue
-        }
-      },
-      {
-        scope: "variable.parameter.function.swift",
-        settings: {
-          foreground: OneHunterColors.alto
-        }
-      },
-      {
-        scope: "entity.name.function.swift",
-        settings: {
-          foreground: OneHunterColors.cornflowerBlue,
-          fontStyle: OneHunterColors["keyword-weight"]
-        }
-      },
-      {
-        scope: [
-          "variable.parameter.function.swift",
-          "meta.parameter-clause.swift"
-        ],
-        settings: {
-          foreground: OneHunterColors.white
-        }
-      },
-      /* Golang */
-      {
-        scope: [
-          "support.function.go"
-        ],
-        settings: {
-          foreground: OneHunterColors.dodgeBlue,
-          fontStyle: OneHunterColors["keyword-weight"],
-        }
-      },
-      {
-        scope: [
-          "keyword.operator.address.go",
-          "keyword.operator.pointer.go",
+          "keyword.operator.custom.infix.swift",
         ],
         settings: {
           foreground: OneHunterColors.cornflowerBlue,
         },
       },
       {
-        // To quickly differentiate concurrency keywords 
+        scope: "variable.parameter.function.swift",
+        settings: {
+          foreground: OneHunterColors.alto,
+        },
+      },
+      {
+        scope: "entity.name.function.swift",
+        settings: {
+          foreground: OneHunterColors.cornflowerBlue,
+          fontStyle: OneHunterColors["keyword-weight"],
+        },
+      },
+      {
         scope: [
-          "keyword.channel.go",
+          "variable.parameter.function.swift",
+          "meta.parameter-clause.swift",
         ],
+        settings: {
+          foreground: OneHunterColors.white,
+        },
+      },
+      /* Golang */
+      {
+        scope: ["support.function.go"],
+        settings: {
+          foreground: OneHunterColors.dodgeBlue,
+          fontStyle: OneHunterColors["keyword-weight"],
+        },
+      },
+      {
+        scope: ["keyword.operator.address.go", "keyword.operator.pointer.go"],
+        settings: {
+          foreground: OneHunterColors.cornflowerBlue,
+        },
+      },
+      {
+        // To quickly differentiate concurrency keywords
+        scope: ["keyword.channel.go"],
         settings: {
           foreground: OneHunterColors.heliotrope,
         },
@@ -1186,7 +1179,7 @@ export default {
         settings: {
           foreground: OneHunterColors.saffronMango,
         },
-      }
+      },
     ],
   },
 };

--- a/themes/iterm2/OneHunter-Classic.itermcolors.xml
+++ b/themes/iterm2/OneHunter-Classic.itermcolors.xml
@@ -1,0 +1,203 @@
+<?xml version="1.0"?>
+<plist version="1.0">
+  <dict>
+    <key>Background Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.09803921568627451</real>
+      <key>Green Component</key>
+      <real>0.11372549019607843</real>
+      <key>Blue Component</key>
+      <real>0.12941176470588237</real>
+    </dict>
+    <key>Foreground Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.8784313725490196</real>
+      <key>Green Component</key>
+      <real>0.8784313725490196</real>
+      <key>Blue Component</key>
+      <real>0.8784313725490196</real>
+    </dict>
+    <key>Ansi 15 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.8784313725490196</real>
+      <key>Green Component</key>
+      <real>0.8784313725490196</real>
+      <key>Blue Component</key>
+      <real>0.8784313725490196</real>
+    </dict>
+    <key>Ansi 8 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.5333333333333333</real>
+      <key>Green Component</key>
+      <real>0.5333333333333333</real>
+      <key>Blue Component</key>
+      <real>0.5333333333333333</real>
+    </dict>
+    <key>Ansi 1 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.9568627450980393</real>
+      <key>Green Component</key>
+      <real>0.27058823529411763</real>
+      <key>Blue Component</key>
+      <real>0.49019607843137253</real>
+    </dict>
+    <key>Ansi 9 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.9568627450980393</real>
+      <key>Green Component</key>
+      <real>0.27058823529411763</real>
+      <key>Blue Component</key>
+      <real>0.49019607843137253</real>
+    </dict>
+    <key>Ansi 2 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.3568627450980392</real>
+      <key>Green Component</key>
+      <real>0.8196078431372549</real>
+      <key>Blue Component</key>
+      <real>0.7254901960784313</real>
+    </dict>
+    <key>Ansi 10 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.3568627450980392</real>
+      <key>Green Component</key>
+      <real>0.8196078431372549</real>
+      <key>Blue Component</key>
+      <real>0.7254901960784313</real>
+    </dict>
+    <key>Ansi 3 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.9764705882352941</real>
+      <key>Green Component</key>
+      <real>0.7647058823529411</real>
+      <key>Blue Component</key>
+      <real>0.35294117647058826</real>
+    </dict>
+    <key>Ansi 11 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.9764705882352941</real>
+      <key>Green Component</key>
+      <real>0.7647058823529411</real>
+      <key>Blue Component</key>
+      <real>0.35294117647058826</real>
+    </dict>
+    <key>Ansi 4 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.3254901960784314</real>
+      <key>Green Component</key>
+      <real>0.6313725490196078</real>
+      <key>Blue Component</key>
+      <real>0.9803921568627451</real>
+    </dict>
+    <key>Ansi 12 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.3254901960784314</real>
+      <key>Green Component</key>
+      <real>0.6313725490196078</real>
+      <key>Blue Component</key>
+      <real>0.9803921568627451</real>
+    </dict>
+    <key>Ansi 5 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.6980392156862745</real>
+      <key>Green Component</key>
+      <real>0.403921568627451</real>
+      <key>Blue Component</key>
+      <real>0.9019607843137255</real>
+    </dict>
+    <key>Ansi 13 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.6980392156862745</real>
+      <key>Green Component</key>
+      <real>0.403921568627451</real>
+      <key>Blue Component</key>
+      <real>0.9019607843137255</real>
+    </dict>
+    <key>Ansi 6 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.2627450980392157</real>
+      <key>Green Component</key>
+      <real>0.6666666666666666</real>
+      <key>Blue Component</key>
+      <real>0.9764705882352941</real>
+    </dict>
+    <key>Ansi 14 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.2627450980392157</real>
+      <key>Green Component</key>
+      <real>0.6666666666666666</real>
+      <key>Blue Component</key>
+      <real>0.9764705882352941</real>
+    </dict>
+    <key>Ansi 7 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>1</real>
+      <key>Green Component</key>
+      <real>1</real>
+      <key>Blue Component</key>
+      <real>1</real>
+    </dict>
+    <key>Ansi 0 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0</real>
+      <key>Green Component</key>
+      <real>0</real>
+      <key>Blue Component</key>
+      <real>0</real>
+    </dict>
+  </dict>
+</plist>

--- a/themes/iterm2/OneHunter-Light.itermcolors.xml
+++ b/themes/iterm2/OneHunter-Light.itermcolors.xml
@@ -1,0 +1,203 @@
+<?xml version="1.0"?>
+<plist version="1.0">
+  <dict>
+    <key>Background Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>1</real>
+      <key>Green Component</key>
+      <real>1</real>
+      <key>Blue Component</key>
+      <real>1</real>
+    </dict>
+    <key>Foreground Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.19215686274509805</real>
+      <key>Green Component</key>
+      <real>0.19215686274509805</real>
+      <key>Blue Component</key>
+      <real>0.19215686274509805</real>
+    </dict>
+    <key>Ansi 15 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>1</real>
+      <key>Green Component</key>
+      <real>1</real>
+      <key>Blue Component</key>
+      <real>1</real>
+    </dict>
+    <key>Ansi 8 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.6588235294117647</real>
+      <key>Green Component</key>
+      <real>0.6588235294117647</real>
+      <key>Blue Component</key>
+      <real>0.6588235294117647</real>
+    </dict>
+    <key>Ansi 1 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.8823529411764706</real>
+      <key>Green Component</key>
+      <real>0.13725490196078433</real>
+      <key>Blue Component</key>
+      <real>0.6039215686274509</real>
+    </dict>
+    <key>Ansi 9 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.8823529411764706</real>
+      <key>Green Component</key>
+      <real>0.13725490196078433</real>
+      <key>Blue Component</key>
+      <real>0.6039215686274509</real>
+    </dict>
+    <key>Ansi 2 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.043137254901960784</real>
+      <key>Green Component</key>
+      <real>0.6431372549019608</real>
+      <key>Blue Component</key>
+      <real>0.38823529411764707</real>
+    </dict>
+    <key>Ansi 10 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.043137254901960784</real>
+      <key>Green Component</key>
+      <real>0.6431372549019608</real>
+      <key>Blue Component</key>
+      <real>0.38823529411764707</real>
+    </dict>
+    <key>Ansi 3 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>1</real>
+      <key>Green Component</key>
+      <real>0.49411764705882355</real>
+      <key>Blue Component</key>
+      <real>0</real>
+    </dict>
+    <key>Ansi 11 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>1</real>
+      <key>Green Component</key>
+      <real>0.49411764705882355</real>
+      <key>Blue Component</key>
+      <real>0</real>
+    </dict>
+    <key>Ansi 4 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.01568627450980392</real>
+      <key>Green Component</key>
+      <real>0.5333333333333333</real>
+      <key>Blue Component</key>
+      <real>0.8588235294117647</real>
+    </dict>
+    <key>Ansi 12 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.01568627450980392</real>
+      <key>Green Component</key>
+      <real>0.5333333333333333</real>
+      <key>Blue Component</key>
+      <real>0.8588235294117647</real>
+    </dict>
+    <key>Ansi 5 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.6980392156862745</real>
+      <key>Green Component</key>
+      <real>0.403921568627451</real>
+      <key>Blue Component</key>
+      <real>0.9019607843137255</real>
+    </dict>
+    <key>Ansi 13 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.6980392156862745</real>
+      <key>Green Component</key>
+      <real>0.403921568627451</real>
+      <key>Blue Component</key>
+      <real>0.9019607843137255</real>
+    </dict>
+    <key>Ansi 6 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.01568627450980392</real>
+      <key>Green Component</key>
+      <real>0.5333333333333333</real>
+      <key>Blue Component</key>
+      <real>0.8588235294117647</real>
+    </dict>
+    <key>Ansi 14 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.01568627450980392</real>
+      <key>Green Component</key>
+      <real>0.5333333333333333</real>
+      <key>Blue Component</key>
+      <real>0.8588235294117647</real>
+    </dict>
+    <key>Ansi 7 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.6588235294117647</real>
+      <key>Green Component</key>
+      <real>0.6588235294117647</real>
+      <key>Blue Component</key>
+      <real>0.6588235294117647</real>
+    </dict>
+    <key>Ansi 0 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0</real>
+      <key>Green Component</key>
+      <real>0</real>
+      <key>Blue Component</key>
+      <real>0</real>
+    </dict>
+  </dict>
+</plist>

--- a/themes/iterm2/OneHunter-Material.itermcolors.xml
+++ b/themes/iterm2/OneHunter-Material.itermcolors.xml
@@ -1,0 +1,203 @@
+<?xml version="1.0"?>
+<plist version="1.0">
+  <dict>
+    <key>Background Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.11372549019607843</real>
+      <key>Green Component</key>
+      <real>0.12941176470588237</real>
+      <key>Blue Component</key>
+      <real>0.14901960784313725</real>
+    </dict>
+    <key>Foreground Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.8901960784313725</real>
+      <key>Green Component</key>
+      <real>0.8823529411764706</real>
+      <key>Blue Component</key>
+      <real>0.8823529411764706</real>
+    </dict>
+    <key>Ansi 15 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.8901960784313725</real>
+      <key>Green Component</key>
+      <real>0.8823529411764706</real>
+      <key>Blue Component</key>
+      <real>0.8823529411764706</real>
+    </dict>
+    <key>Ansi 8 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.6196078431372549</real>
+      <key>Green Component</key>
+      <real>0.6196078431372549</real>
+      <key>Blue Component</key>
+      <real>0.6196078431372549</real>
+    </dict>
+    <key>Ansi 1 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.9411764705882353</real>
+      <key>Green Component</key>
+      <real>0.3843137254901961</real>
+      <key>Blue Component</key>
+      <real>0.5725490196078431</real>
+    </dict>
+    <key>Ansi 9 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.9411764705882353</real>
+      <key>Green Component</key>
+      <real>0.3843137254901961</real>
+      <key>Blue Component</key>
+      <real>0.5725490196078431</real>
+    </dict>
+    <key>Ansi 2 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.4</real>
+      <key>Green Component</key>
+      <real>0.8745098039215686</real>
+      <key>Blue Component</key>
+      <real>0.7686274509803922</real>
+    </dict>
+    <key>Ansi 10 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.4</real>
+      <key>Green Component</key>
+      <real>0.8745098039215686</real>
+      <key>Blue Component</key>
+      <real>0.7686274509803922</real>
+    </dict>
+    <key>Ansi 3 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.9686274509803922</real>
+      <key>Green Component</key>
+      <real>0.7372549019607844</real>
+      <key>Blue Component</key>
+      <real>0.3843137254901961</real>
+    </dict>
+    <key>Ansi 11 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.9686274509803922</real>
+      <key>Green Component</key>
+      <real>0.7372549019607844</real>
+      <key>Blue Component</key>
+      <real>0.3843137254901961</real>
+    </dict>
+    <key>Ansi 4 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.39215686274509803</real>
+      <key>Green Component</key>
+      <real>0.7098039215686275</real>
+      <key>Blue Component</key>
+      <real>0.9647058823529412</real>
+    </dict>
+    <key>Ansi 12 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.39215686274509803</real>
+      <key>Green Component</key>
+      <real>0.7098039215686275</real>
+      <key>Blue Component</key>
+      <real>0.9647058823529412</real>
+    </dict>
+    <key>Ansi 5 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.788235294117647</real>
+      <key>Green Component</key>
+      <real>0.4470588235294118</real>
+      <key>Blue Component</key>
+      <real>0.8470588235294118</real>
+    </dict>
+    <key>Ansi 13 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.788235294117647</real>
+      <key>Green Component</key>
+      <real>0.4470588235294118</real>
+      <key>Blue Component</key>
+      <real>0.8470588235294118</real>
+    </dict>
+    <key>Ansi 6 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.30980392156862746</real>
+      <key>Green Component</key>
+      <real>0.7647058823529411</real>
+      <key>Blue Component</key>
+      <real>0.9686274509803922</real>
+    </dict>
+    <key>Ansi 14 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.30980392156862746</real>
+      <key>Green Component</key>
+      <real>0.7647058823529411</real>
+      <key>Blue Component</key>
+      <real>0.9686274509803922</real>
+    </dict>
+    <key>Ansi 7 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>1</real>
+      <key>Green Component</key>
+      <real>1</real>
+      <key>Blue Component</key>
+      <real>1</real>
+    </dict>
+    <key>Ansi 0 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0</real>
+      <key>Green Component</key>
+      <real>0</real>
+      <key>Blue Component</key>
+      <real>0</real>
+    </dict>
+  </dict>
+</plist>

--- a/themes/iterm2/OneHunter-Vercel.itermcolors.xml
+++ b/themes/iterm2/OneHunter-Vercel.itermcolors.xml
@@ -1,0 +1,203 @@
+<?xml version="1.0"?>
+<plist version="1.0">
+  <dict>
+    <key>Background Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0</real>
+      <key>Green Component</key>
+      <real>0</real>
+      <key>Blue Component</key>
+      <real>0</real>
+    </dict>
+    <key>Foreground Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.8627450980392157</real>
+      <key>Green Component</key>
+      <real>0.8901960784313725</real>
+      <key>Blue Component</key>
+      <real>0.9176470588235294</real>
+    </dict>
+    <key>Ansi 15 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.8627450980392157</real>
+      <key>Green Component</key>
+      <real>0.8901960784313725</real>
+      <key>Blue Component</key>
+      <real>0.9176470588235294</real>
+    </dict>
+    <key>Ansi 8 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.5333333333333333</real>
+      <key>Green Component</key>
+      <real>0.5333333333333333</real>
+      <key>Blue Component</key>
+      <real>0.5333333333333333</real>
+    </dict>
+    <key>Ansi 1 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.8666666666666667</real>
+      <key>Green Component</key>
+      <real>0.30980392156862746</real>
+      <key>Blue Component</key>
+      <real>0.49019607843137253</real>
+    </dict>
+    <key>Ansi 9 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.8666666666666667</real>
+      <key>Green Component</key>
+      <real>0.30980392156862746</real>
+      <key>Blue Component</key>
+      <real>0.49019607843137253</real>
+    </dict>
+    <key>Ansi 2 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.3568627450980392</real>
+      <key>Green Component</key>
+      <real>0.8196078431372549</real>
+      <key>Blue Component</key>
+      <real>0.7254901960784313</real>
+    </dict>
+    <key>Ansi 10 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.3568627450980392</real>
+      <key>Green Component</key>
+      <real>0.8196078431372549</real>
+      <key>Blue Component</key>
+      <real>0.7254901960784313</real>
+    </dict>
+    <key>Ansi 3 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.9803921568627451</real>
+      <key>Green Component</key>
+      <real>0.7803921568627451</real>
+      <key>Blue Component</key>
+      <real>0.3764705882352941</real>
+    </dict>
+    <key>Ansi 11 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.9803921568627451</real>
+      <key>Green Component</key>
+      <real>0.7803921568627451</real>
+      <key>Blue Component</key>
+      <real>0.3764705882352941</real>
+    </dict>
+    <key>Ansi 4 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.2627450980392157</real>
+      <key>Green Component</key>
+      <real>0.6666666666666666</real>
+      <key>Blue Component</key>
+      <real>0.9764705882352941</real>
+    </dict>
+    <key>Ansi 12 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.2627450980392157</real>
+      <key>Green Component</key>
+      <real>0.6666666666666666</real>
+      <key>Blue Component</key>
+      <real>0.9764705882352941</real>
+    </dict>
+    <key>Ansi 5 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.6980392156862745</real>
+      <key>Green Component</key>
+      <real>0.403921568627451</real>
+      <key>Blue Component</key>
+      <real>0.9019607843137255</real>
+    </dict>
+    <key>Ansi 13 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.6980392156862745</real>
+      <key>Green Component</key>
+      <real>0.403921568627451</real>
+      <key>Blue Component</key>
+      <real>0.9019607843137255</real>
+    </dict>
+    <key>Ansi 6 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.2627450980392157</real>
+      <key>Green Component</key>
+      <real>0.6666666666666666</real>
+      <key>Blue Component</key>
+      <real>0.9764705882352941</real>
+    </dict>
+    <key>Ansi 14 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0.2627450980392157</real>
+      <key>Green Component</key>
+      <real>0.6666666666666666</real>
+      <key>Blue Component</key>
+      <real>0.9764705882352941</real>
+    </dict>
+    <key>Ansi 7 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>1</real>
+      <key>Green Component</key>
+      <real>1</real>
+      <key>Blue Component</key>
+      <real>1</real>
+    </dict>
+    <key>Ansi 0 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Red Component</key>
+      <real>0</real>
+      <key>Green Component</key>
+      <real>0</real>
+      <key>Blue Component</key>
+      <real>0</real>
+    </dict>
+  </dict>
+</plist>


### PR DESCRIPTION
###  Classic
<img width="957" alt="image" src="https://github.com/Railly/one-hunter-vscode/assets/51397083/e61327e3-1693-467e-abc2-dffe25ad05fb">

### Material
<img width="959" alt="image" src="https://github.com/Railly/one-hunter-vscode/assets/51397083/76f58684-2cea-4db9-9a0a-587a52193294">

### Vercel
<img width="959" alt="image" src="https://github.com/Railly/one-hunter-vscode/assets/51397083/5a5e66e0-32e9-42c2-bfd9-ecf0e7c9e10b">

### Light
<img width="958" alt="image" src="https://github.com/Railly/one-hunter-vscode/assets/51397083/e94829b8-57a1-4bb2-9d10-238b0594acec">

Closes #48