### PR TITLE
fix: add C++ token colors with brighter variables for Material theme (#70)

### DIFF
--- a/demos/cpp.cpp
+++ b/demos/cpp.cpp
@@ -1,0 +1,290 @@
+// Preprocessor directives
+#include <iostream>
+#include <vector>
+#include <map>
+#include <set>
+#include <algorithm>
+#include <string>
+#include <memory>
+#include <functional>
+#include <exception>
+#include <thread>
+#include <mutex>
+#include <chrono>
+#include <cctype>  // For character functions
+#include <cmath>   // Math functions like sin, cos
+
+#define PI 3.141592653589793
+#define SQUARE(x) ((x) * (x))
+
+// Namespaces
+using namespace std;
+
+// Constants
+constexpr int MAX_VALUE = 100;
+const double GRAVITY = 9.8;
+
+// Enums
+enum Color { RED, GREEN, BLUE };
+enum class Shape : int { Circle = 1, Square, Triangle };
+
+// Structs
+struct Point {
+    int x;
+    int y;
+};
+
+// Unions
+union Variant {
+    int i;
+    float f;
+    char c;
+};
+
+// Classes with inheritance
+class Base {
+public:
+    virtual ~Base() = default;
+    virtual void display() const {
+        cout << "Base class" << endl;
+    }
+protected:
+    int protectedVar = 42;
+private:
+    string privateStr = "secret";
+};
+
+class Derived : public Base {
+public:
+    void display() const override {
+        cout << "Derived class" << endl;
+    }
+    explicit Derived(int val) : value(val) {}
+private:
+    int value;
+};
+
+// Templates
+template <typename T>
+class Stack {
+private:
+    vector<T> elements;
+public:
+    void push(const T& item) {
+        elements.push_back(item);
+    }
+    T pop() {
+        if (elements.empty()) {
+            throw out_of_range("Stack underflow");
+        }
+        T top = elements.back();
+        elements.pop_back();
+        return top;
+    }
+};
+
+template <typename T, int N>
+T addValue(T x) {
+    return x + N;
+}
+
+// Lambdas and function objects
+auto lambdaFunc = [](int a, int b) -> int {
+    return a + b;
+};
+
+function<int(int, int)> adder = lambdaFunc;
+
+// Main function with various elements
+int main() {
+    // Variables of different types
+    bool flag = true;
+    char ch = 'A';
+    unsigned short us = 65535;
+    int integer = -123;
+    unsigned int ui = 4294967295U;
+    long long ll = 9223372036854775807LL;
+    float fl = 3.14f;
+    double dbl = 2.71828;
+    long double ld = 1.618033988749895L;
+    string str = "Hello, World!";
+    wstring wstr = L"Wide string";
+    const char* cstr = "C-style string";
+    char arr[] = "Array string";
+
+    // Pointers and references
+    int* ptr = &integer;
+    int& ref = integer;
+    unique_ptr<int> smartPtr = make_unique<int>(10);
+    shared_ptr<Base> sharedBase = make_shared<Derived>(5);
+
+    // Arrays and STL containers
+    int fixedArray[5] = {1, 2, 3, 4, 5};
+    vector<int> vec = {10, 20, 30};
+    map<string, int> mp = {{"one", 1}, {"two", 2}};
+    set<double> st = {1.1, 2.2, 3.3};
+
+    // Algorithms
+    sort(vec.begin(), vec.end());
+    auto it = find(vec.begin(), vec.end(), 20);
+    if (it != vec.end()) {
+        cout << "Found: " << *it << endl;
+    }
+
+    // Loops
+    for (int i = 0; i < 5; ++i) {
+        cout << i << " ";
+    }
+    cout << endl;
+
+    int j = 0;
+    while (j < 5) {
+        cout << j << " ";
+        ++j;
+    }
+    cout << endl;
+
+    int k = 0;
+    do {
+        cout << k << " ";
+        ++k;
+    } while (k < 5);
+    cout << endl;
+
+    for (auto& elem : vec) {
+        elem *= 2;
+    }
+
+    // Conditionals
+    if (flag) {
+        cout << "True" << endl;
+    } else if (integer > 0) {
+        cout << "Positive" << endl;
+    } else {
+        cout << "Negative or zero" << endl;
+    }
+
+    switch (ch) {
+        case 'A':
+            cout << "Apple" << endl;
+            break;
+        case 'B':
+            cout << "Banana" << endl;
+            [[fallthrough]];
+        default:
+            cout << "Default" << endl;
+    }
+
+    // Ternary operator
+    string result = (integer > 0) ? "Positive" : "Non-positive";
+
+    // Functions and calls
+    cout << addValue<int, 5>(10) << endl;
+    cout << lambdaFunc(3, 4) << endl;
+
+    // Exceptions
+    try {
+        Stack<int> stk;
+        stk.push(1);
+        cout << stk.pop() << endl;
+        cout << stk.pop() << endl;  
+    } catch (const exception& e) {
+        cerr << "Caught: " << e.what() << endl;
+    }
+
+    // Threads and concurrency
+    mutex mtx;
+    thread th([&]() {
+        lock_guard<mutex> lock(mtx);
+        cout << "Thread running" << endl;
+        this_thread::sleep_for(chrono::seconds(1));
+    });
+    th.join();
+
+    // Math and other operations
+    double sine = sin(PI / 2);
+    int squared = SQUARE(5);
+    bool isAlpha = isalpha(ch);
+
+    // Casting
+    static_cast<double>(integer);
+    reinterpret_cast<void*>(ptr);
+
+
+    // Bitwise operators
+    int bitAnd = 5 & 3;
+    int bitOr = 5 | 3;
+    int bitXor = 5 ^ 3;
+    int bitNot = ~5;
+    int leftShift = 5 << 1;
+    int rightShift = 5 >> 1;
+
+    // Logical operators
+    bool logAnd = flag && true;
+    bool logOr = flag || false;
+    bool logNot = !flag;
+
+    // Assignment and compound
+    integer += 10;
+    fl *= 2.0;
+    ui %= 100;
+
+    // Increment/decrement
+    ++j;
+    k--;
+
+    // Sizeof and alignof
+    size_t sz = sizeof(int);
+    alignas(16) int alignedVar;
+
+    // New and delete
+    int* dyn = new int(100);
+    delete dyn;
+    int* dynArr = new int[10];
+    delete[] dynArr;
+
+    // Polymorphism
+    Base* basePtr = new Derived(7);
+    basePtr->display();
+    delete basePtr;
+
+
+    // Inline and noexcept
+    inline void inlineFunc() noexcept {
+        // Do nothing
+    }
+
+    // Variadic templates (example declaration)
+    template<typename... Args>
+    void variadic(Args... args);
+
+    // Raw string literals
+    string rawStr = R"(Raw string with "quotes" and \escapes)";
+
+    // User-defined literals
+    long double operator"" _km(long double val) { return val * 1000; }
+    auto distance = 5.5_km;
+
+    // Attributes
+    [[nodiscard]] int importantFunc() { return 42; }
+    [[maybe_unused]] int unusedVar = 0;
+
+
+
+    return 0;
+}
+
+// More functions outside main
+void friendFunc() {}
+template<typename... Args>
+void variadic(Args... args) {}
+
+// Overloaded operators
+Point operator+(const Point& a, const Point& b) {
+    return {a.x + b.x, a.y + b.y};
+}
+
+ostream& operator<<(ostream& os, const Point& p) {
+    os << "(" << p.x << ", " << p.y << ")";
+    return os;
+}

--- a/src/variants/token-colors/one-hunter.ts
+++ b/src/variants/token-colors/one-hunter.ts
@@ -803,4 +803,50 @@ export const oneHunterTokenColors = [
       fontStyle: "",
     },
   },
+  /* C++ */
+  {
+    scope: "variable.cpp",
+    settings: {
+      foreground: OneHunterColorsObject.cyanBase,
+    },
+  },
+  {
+    scope: "variable.parameter.cpp",
+    settings: {
+      foreground: OneHunterColorsObject.cyanBase,
+      fontStyle: "italic",
+    },
+  },
+  {
+    scope: "keyword.control.cpp",
+    settings: {
+      foreground: OneHunterColorsObject.pinkBase,
+    },
+  },
+  {
+    scope: "storage.type.cpp",
+    settings: {
+      foreground: OneHunterColorsObject.blueBase,
+    },
+  },
+  {
+    scope: "entity.name.function.cpp",
+    settings: {
+      foreground: OneHunterColorsObject.blueDark,
+      fontStyle: "bold",
+    },
+  },
+  {
+    scope: "string.quoted.double.cpp",
+    settings: {
+      foreground: OneHunterColorsObject.cyanBase,
+    },
+  },
+  {
+    scope: "comment.cpp",
+    settings: {
+      foreground: OneHunterColorsObject.gray,
+      fontStyle: "italic",
+
+  },
 ];

--- a/themes/OneHunter-Material-color-theme.json
+++ b/themes/OneHunter-Material-color-theme.json
@@ -1,554 +1,958 @@
 {
-  "name": "One Hunter Material",
+  "name": "One Hunter Theme",
   "type": "dark",
   "colors": {
-    "editor.background": "#1D2126",
+    "editor.background": "#1d2126",
     "editor.foreground": "#E3E1E1",
-    "editor.hoverHighlightBackground": "#3D4043",
-    "editor.lineHighlightBackground": "#2B2E31",
-    "editor.selectionBackground": "#E3E1E133",
-    "editor.selectionHighlightBackground": "#E3E1E133",
-    "editor.findMatchBackground": "#bc5412",
-    "editor.findMatchHighlightBackground": "#bc5412cc",
-    "editor.findRangeHighlightBackground": "#2B2E31",
-    "editor.inactiveSelectionBackground": "#34373A",
-    "editor.lineHighlightBorder": "#34373A",
-    "editor.rangeHighlightBackground": "#46494D",
-    "notifications.background": "#34373A",
-    "editorInlayHint.typeBackground": "#3D4043",
-    "editorInlayHint.typeForeground": "#E3E1E1",
-    "editorWhitespace.foreground": "#46494D",
-    "editorIndentGuide.background1": "#3D4043",
-    "editorHoverWidget.background": "#34373A",
-    "editorLineNumber.activeForeground": "#E3E1E1",
-    "editorLineNumber.foreground": "#46494D",
-    "editorGutter.background": "#1D2126",
-    "editorGutter.modifiedBackground": "#4fc3f7",
+    "editor.hoverHighlightBackground": "#F0629222",
+    "editor.lineHighlightBackground": "#1d212622",
+    "editor.selectionBackground": "#64B5F655",
+    "editor.wordHighlightBackground": "#64B5F622",
+    "editor.wordHighlightStrongBackground": "#64B5F622",
+    "editorBracketMatch.background": "#F0629244",
+    "editorBracketMatch.border": "#64B5F6",
+    "editorCursor.foreground": "#E3E1E1",
     "editorGutter.addedBackground": "#66dfc4",
-    "editorGutter.deletedBackground": "#f06292",
-    "editorBracketMatch.background": "#34373A",
-    "editorBracketMatch.border": "#3D4043",
-    "editorError.foreground": "#f06292",
-    "editorWarning.foreground": "#f4a343",
-    "editorInfo.foreground": "#64b5f6",
-    "diffEditor.insertedTextBackground": "#176e6199",
-    "diffEditor.removedTextBackground": "#bb1b3f99",
-    "editorGroupHeader.tabsBackground": "#1D2126",
-    "editorGroup.border": "#3D4043",
-    "tab.activeBackground": "#1D2126",
-    "tab.inactiveBackground": "#2B2E31",
-    "tab.inactiveForeground": "#7F8286",
-    "tab.activeForeground": "#E3E1E1",
-    "tab.hoverBackground": "#3D4043",
-    "tab.unfocusedHoverBackground": "#3D4043",
-    "tab.border": "#3D4043",
-    "tab.activeModifiedBorder": "#f7bc62",
-    "tab.inactiveModifiedBorder": "#64b5f6",
-    "tab.unfocusedActiveModifiedBorder": "#bc5412",
-    "tab.unfocusedInactiveModifiedBorder": "#2263d3",
-    "editorWidget.background": "#2B2E31",
-    "editorWidget.border": "#3D4043",
-    "editorSuggestWidget.background": "#1D2126",
-    "editorSuggestWidget.border": "#3D4043",
+    "editorGutter.background": "#1d2126",
+    "editorGutter.deletedBackground": "#EF5350",
+    "editorGutter.modifiedBackground": "#F7BC62",
+    "editorIndentGuide.background": "#1d212688",
+    "editorInlayHint.background": "#3B4145",
+    "editorInlayHint.foreground": "#E3E1E1",
+    "editorLineNumber.foreground": "#454d54",
+    "editorLink.activeForeground": "#F06292",
+    "editorOverviewRuler.addedForeground": "#66dfc4",
+    "editorOverviewRuler.deletedForeground": "#EF5350",
+    "editorOverviewRuler.errorForeground": "#EF5350",
+    "editorOverviewRuler.findMatchForeground": "#64B5F655",
+    "editorOverviewRuler.infoForeground": "#C972D8",
+    "editorOverviewRuler.modifiedForeground": "#F7BC62",
+    "editorOverviewRuler.warningForeground": "#F7BC62",
+    "editorRuler.foreground": "#3B4145",
     "editorSuggestWidget.foreground": "#E3E1E1",
-    "editorSuggestWidget.highlightForeground": "#7F8286",
-    "editorSuggestWidget.selectedBackground": "#3D4043",
-    "peekView.border": "#3D4043",
-    "peekViewEditor.background": "#1D2126",
-    "peekViewEditor.matchHighlightBackground": "#46494D",
-    "peekViewResult.background": "#2B2E31",
-    "peekViewResult.fileForeground": "#E3E1E1",
-    "peekViewResult.lineForeground": "#7F8286",
-    "peekViewResult.matchHighlightBackground": "#46494D",
-    "peekViewResult.selectionBackground": "#34373A",
-    "peekViewResult.selectionForeground": "#595D61",
-    "peekViewTitle.background": "#3D4043",
-    "peekViewTitleDescription.foreground": "#7F8286",
-    "peekViewTitleLabel.foreground": "#E3E1E1",
-    "merge.currentHeaderBackground": "#66dfc4",
-    "merge.currentContentBackground": "#176e61",
-    "merge.incomingHeaderBackground": "#4fc3f7",
-    "merge.incomingContentBackground": "#05699f",
-    "merge.border": "#3D4043",
-    "merge.commonContentBackground": "#46494D",
-    "merge.commonHeaderBackground": "#3D4043",
-    "panel.background": "#1D2126",
-    "panel.border": "#3D4043",
-    "panelTitle.activeBorder": "#46494D",
-    "panelTitle.activeForeground": "#E3E1E1",
-    "panelTitle.inactiveForeground": "#7F8286",
-    "statusBar.background": "#1D2126",
-    "statusBar.foreground": "#E3E1E1",
-    "statusBar.border": "#3D4043",
-    "statusBar.debuggingBackground": "#f06292",
-    "statusBar.debuggingForeground": "#E3E1E1",
-    "statusBar.noFolderBackground": "#46494D",
-    "statusBar.noFolderForeground": "#595D61",
-    "titleBar.activeBackground": "#1D2126",
-    "titleBar.activeForeground": "#E3E1E1",
-    "titleBar.inactiveBackground": "#2B2E31",
-    "titleBar.inactiveForeground": "#7F8286",
-    "titleBar.border": "#3D4043",
-    "menu.foreground": "#E3E1E1",
-    "menu.background": "#1D2126",
-    "menu.selectionForeground": "#E3E1E1",
-    "menu.selectionBackground": "#3D4043",
-    "menu.border": "#3D4043",
-    "editorInlayHint.foreground": "#7F8286",
-    "editorInlayHint.background": "#3D4043",
-    "terminal.foreground": "#E3E1E1",
-    "terminal.background": "#1D2126",
-    "terminalCursor.foreground": "#E3E1E1",
-    "terminalCursor.background": "#1D2126",
-    "terminal.ansiRed": "#f06292",
-    "terminal.ansiGreen": "#66dfc4",
-    "terminal.ansiYellow": "#f7bc62",
-    "terminal.ansiBlue": "#64b5f6",
-    "terminal.ansiMagenta": "#4fc3f7",
-    "terminal.ansiCyan": "#4fc3f7",
-    "activityBar.background": "#1D2126",
-    "activityBar.foreground": "#E3E1E1",
-    "activityBar.inactiveForeground": "#7F8286",
-    "activityBar.activeBorder": "#E3E1E1",
-    "activityBar.border": "#3D4043",
-    "sideBar.background": "#1D2126",
+    "editorSuggestWidget.highlightForeground": "#F06292",
+    "editorSuggestWidget.selectedBackground": "#454d54",
+    "editorWhitespace.foreground": "#3B4145",
+    "editorWidget.background": "#3B4145",
+    "editorWidget.border": "#454d54",
+    "sideBar.background": "#191d21",
     "sideBar.foreground": "#E3E1E1",
-    "sideBar.border": "#3D4043",
-    "sideBarTitle.foreground": "#E3E1E1",
-    "sideBarSectionHeader.background": "#2B2E31",
+    "sideBarSectionHeader.background": "#15181b",
     "sideBarSectionHeader.foreground": "#E3E1E1",
-    "sideBarSectionHeader.border": "#3D4043",
-    "sideBar.activeBackground": "#46494D",
-    "sideBar.activeForeground": "#E3E1E1",
-    "sideBar.hoverBackground": "#3D4043",
-    "sideBar.hoverForeground": "#7F8286",
-    "sideBar.folderIcon.foreground": "#66dfc4",
-    "sideBar.fileIcon.foreground": "#64b5f6",
-    "list.warningForeground": "#f4a343",
-    "list.errorForeground": "#f06292",
-    "list.inactiveSelectionBackground": "#3D4043",
-    "list.activeSelectionBackground": "#46494D",
-    "list.inactiveSelectionForeground": "#E3E1E1",
+    "badge.background": "#F06292",
+    "badge.foreground": "#E3E1E1",
+    "list.activeSelectionBackground": "#F0629255",
     "list.activeSelectionForeground": "#E3E1E1",
-    "list.hoverForeground": "#E3E1E1",
-    "list.hoverBackground": "#3D4043",
-    "input.background": "#2B2E31",
-    "input.foreground": "#E3E1E1",
-    "input.border": "#3D4043",
-    "input.placeholderForeground": "#7F8286",
-    "inputOption.activeBorder": "#3D4043",
-    "inputOption.activeBackground": "#34373A",
-    "inputOption.activeForeground": "#E3E1E1",
-    "inputValidation.infoBackground": "#4fc3f7",
-    "inputValidation.infoBorder": "#05699f",
-    "inputValidation.warningBackground": "#f4a343",
-    "inputValidation.warningBorder": "#bc5412",
-    "inputValidation.errorBackground": "#f06292",
-    "inputValidation.errorBorder": "#bb1b3f",
-    "dropdown.background": "#2B2E31",
+    "list.focusBackground": "#3a4147",
+    "list.hoverBackground": "#21252a",
+    "list.inactiveSelectionBackground": "#1d2126",
+    "titleBar.activeBackground": "#15181b",
+    "activityBar.background": "#15181b",
+    "activityBar.foreground": "#E3E1E1",
+    "activityBarBadge.background": "#F06292",
+    "activityBarBadge.foreground": "#E3E1E1",
+    "editorGroupHeader.tabsBackground": "#21252a",
+    "tab.inactiveBackground": "#3a414744",
+    "tab.inactiveForeground": "#E3E1E188",
+    "tab.activeModifiedBorder": "#F7BC62",
+    "tab.inactiveModifiedBorder": "#64B5F6",
+    "tab.unfocusedActiveModifiedBorder": "#F7BC6288",
+    "tab.unfocusedInactiveModifiedBorder": "#64B5F688",
+    "terminal.ansiBlack": "#3B4145",
+    "terminal.ansiBlue": "#64B5F6",
+    "terminal.ansiBrightBlack": "#454d54",
+    "terminal.ansiBrightBlue": "#90CAF9",
+    "terminal.ansiBrightCyan": "#E1BEE7",
+    "terminal.ansiBrightGreen": "#B2EBF2",
+    "terminal.ansiBrightMagenta": "#EC407A",
+    "terminal.ansiBrightRed": "#EF5350",
+    "terminal.ansiBrightWhite": "#E3E1E1",
+    "terminal.ansiBrightYellow": "#90CAF9",
+    "terminal.ansiCyan": "#C972D8",
+    "terminal.ansiGreen": "#66dfc4",
+    "terminal.ansiMagenta": "#F06292",
+    "terminal.ansiRed": "#EF5350",
+    "terminal.ansiWhite": "#E3E1E1",
+    "terminal.ansiYellow": "#64B5F6",
+    "terminal.background": "#1d2126",
+    "terminal.foreground": "#E3E1E1",
+    "gitDecoration.conflictingResourceForeground": "#C972D8",
+    "gitDecoration.deletedResourceForeground": "#EF5350",
+    "gitDecoration.ignoredResourceForeground": "#454d54",
+    "gitDecoration.modifiedResourceForeground": "#F7BC62",
+    "gitDecoration.untrackedResourceForeground": "#66dfc4",
+    "statusBar.background": "#15181b",
+    "statusBar.foreground": "#E3E1E1",
+    "statusBar.noFolderBackground": "#15181b",
+    "scrollbar.shadow": "#15181b",
+    "scrollbarSlider.activeBackground": "#F06292aa",
+    "scrollbarSlider.background": "#454d54aa",
+    "scrollbarSlider.hoverBackground": "#F0629255",
+    "button.background": "#64B5F6",
+    "button.foreground": "#E3E1E1",
+    "dropdown.background": "#15181b",
+    "dropdown.border": "#15181b",
     "dropdown.foreground": "#E3E1E1",
-    "dropdown.border": "#3D4043",
-    "dropdown.listBackground": "#1D2126",
-    "badge.background": "#4fc3f7",
-    "activityBarBadge.background": "#4fc3f7",
-    "button.background": "#4fc3f7",
-    "button.foreground": "#1D2126",
-    "badge.foreground": "#1D2126",
-    "activityBarBadge.foreground": "#1D2126"
+    "extensionButton.prominentBackground": "#F06292",
+    "extensionButton.prominentForeground": "#E3E1E1",
+    "extensionButton.prominentHoverBackground": "#EC407A",
+    "focusBorder": "#F06292",
+    "foreground": "#E3E1E1",
+    "input.background": "#15181b",
+    "input.border": "#454d54",
+    "input.foreground": "#E3E1E1",
+    "input.placeholderForeground": "#454d54",
+    "inputOption.activeBorder": "#64B5F6",
+    "panel.background": "#1d2126",
+    "panel.border": "#454d54",
+    "panelTitle.activeBorder": "#F06292",
+    "panelTitle.inactiveForeground": "#454d54",
+    "peekView.border": "#F06292",
+    "peekViewEditor.background": "#15181b",
+    "peekViewEditor.matchHighlightBackground": "#64B5F655",
+    "peekViewEditorGutter.background": "#15181b",
+    "peekViewResult.background": "#3B4145",
+    "peekViewResult.fileForeground": "#E3E1E1",
+    "peekViewResult.lineForeground": "#E0E0E0",
+    "peekViewResult.matchHighlightBackground": "#64B5F655",
+    "peekViewResult.selectionBackground": "#21252a",
+    "peekViewResult.selectionForeground": "#E3E1E1",
+    "peekViewTitle.background": "#15181b",
+    "peekViewTitleDescription.foreground": "#E3E1E1",
+    "peekViewTitleLabel.foreground": "#E0E0E0",
+    "progressBar.background": "#64B5F6"
   },
   "tokenColors": [
     {
-      "name": "plain",
-      "scope": ["source", "support.type.property-name.css"],
+      "scope": [
+        "comment"
+      ],
+      "settings": {
+        "foreground": "#9E9E9E"
+      }
+    },
+    {
+      "scope": [
+        "comment.block.documentation",
+        "comment.block.documentation variable.other"
+      ],
+      "settings": {
+        "foreground": "#9E9E9E"
+      }
+    },
+    {
+      "scope": [
+        "comment.block.documentation entity.name.type"
+      ],
+      "settings": {
+        "foreground": "#64B5F6"
+      }
+    },
+    {
+      "scope": [
+        "comment.block.documentation storage.type"
+      ],
       "settings": {
         "foreground": "#E3E1E1"
       }
     },
     {
-      "name": "classes",
-      "scope": ["entity.name.type.class"],
-      "settings": {
-        "foreground": "#f7bc62"
-      }
-    },
-    {
-      "name": "interfaces",
-      "scope": ["entity.name.type.interface", "entity.name.type"],
-      "settings": {
-        "foreground": "#f7bc62"
-      }
-    },
-    {
-      "name": "structs",
-      "scope": ["entity.name.type.struct"],
-      "settings": {
-        "foreground": "#f7bc62"
-      }
-    },
-    {
-      "name": "enums",
-      "scope": ["entity.name.type.enum"],
-      "settings": {
-        "foreground": "#f7bc62"
-      }
-    },
-    {
-      "name": "keys",
-      "scope": ["meta.object-literal.key", "support.type.property-name"],
-      "settings": {
-        "foreground": "#f06292"
-      }
-    },
-    {
-      "name": "methods",
-      "scope": ["entity.name.function.method", "meta.function.method"],
-      "settings": {
-        "foreground": "#4fc3f7"
-      }
-    },
-    {
-      "name": "functions",
       "scope": [
-        "entity.name.function",
-        "support.function",
-        "meta.function-call.generic"
+        "string",
+        "punctuation.definition.string.template"
       ],
       "settings": {
-        "foreground": "#4fc3f7",
+        "foreground": "#66dfc4"
+      }
+    },
+    {
+      "scope": "constant.numeric",
+      "settings": {
+        "foreground": "#F7BC62"
+      }
+    },
+    {
+      "scope": "constant.language",
+      "settings": {
+        "foreground": "#4FC3F7"
+      }
+    },
+    {
+      "scope": [
+        "constant.character",
+        "constant.other"
+      ],
+      "settings": {
+        "foreground": "#64B5F6"
+      }
+    },
+    {
+      "scope": "variable.language.this",
+      "settings": {
+        "foreground": "#4FC3F7"
+      }
+    },
+    {
+      "scope": [
+        "keyword",
+        "keyword.operator.new",
+        "storage.modifier.async",
+        "keyword.operator.less"
+      ],
+      "settings": {
+        "foreground": "#F06292",
         "fontStyle": "bold"
       }
     },
     {
-      "name": "variables",
-      "scope": ["variable", "meta.variable", "variable.other.object.property"],
+      "scope": "keyword.operator",
+      "settings": {
+        "foreground": "#F5F5F5"
+      }
+    },
+    {
+      "scope": "punctuation",
+      "settings": {
+        "foreground": "#F5F5F5"
+      }
+    },
+    {
+      "scope": "punctuation.definition.comment",
+      "settings": {
+        "foreground": "#9E9E9E"
+      }
+    },
+    {
+      "scope": "punctuation.definition.tag",
       "settings": {
         "foreground": "#E3E1E1"
       }
     },
     {
-      "name": "variablesOther",
-      "scope": ["variable.other.object", "variable.other.readwrite.alias"],
+      "scope": "string.quoted punctuation.definition.string",
       "settings": {
-        "foreground": "#E3E1E1"
+        "foreground": "#66dfc4"
       }
     },
     {
-      "name": "globalVariables",
-      "scope": ["variable.other.global", "variable.language.this"],
-      "settings": {
-        "foreground": "#4fc3f7"
-      }
-    },
-    {
-      "name": "localVariables",
-      "scope": ["variable.other.local"],
-      "settings": {
-        "foreground": "#34373A"
-      }
-    },
-    {
-      "name": "parameters",
-      "scope": ["variable.parameter", "meta.parameter"],
-      "settings": {
-        "foreground": "#E3E1E1"
-      }
-    },
-    {
-      "name": "properties",
-      "scope": ["variable.other.property", "meta.property"],
-      "settings": {
-        "foreground": "#E3E1E1"
-      }
-    },
-    {
-      "name": "strings",
       "scope": [
-        "string",
-        "string.other.link",
-        "markup.inline.raw.string.markdown",
-        "markup.inline.raw.code.mdx"
+        "string.regexp",
+        "string.regexp punctuation.definition.string"
       ],
       "settings": {
         "foreground": "#66dfc4"
       }
     },
     {
-      "name": "stringEscapeSequences",
-      "scope": ["constant.character.escape", "constant.other.placeholder"],
+      "scope": "storage",
+      "settings": {
+        "foreground": "#4FC3F7"
+      }
+    },
+    {
+      "scope": "storage.type",
+      "settings": {
+        "foreground": "#F06292",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": "entity.name.class",
+      "settings": {
+        "foreground": "#64B5F6"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.function",
+        "meta.require",
+        "support.function.any-method",
+        "variable.function",
+        "support.function.builtin.python",
+        "meta.function-call.generic.python"
+      ],
+      "settings": {
+        "foreground": "#4FC3F7",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": [
+        "keyword.operator.assignment",
+        "keyword.operator.arithmetic",
+        "keyword.operator.bitwise",
+        "keyword.operator.relational",
+        "keyword.operator.increment",
+        "keyword.operator.decrement",
+        "keyword.operator.logical",
+        "keyword.operator.comparison",
+        "keyword.operator.ternary",
+        "keyword.operator.expression"
+      ],
+      "settings": {
+        "foreground": "#64B5F6"
+      }
+    },
+    {
+      "scope": "variable.parameter",
       "settings": {
         "foreground": "#E3E1E1"
       }
     },
     {
-      "name": "keywords",
-      "scope": ["keyword"],
-      "settings": {
-        "foreground": "#f06292"
-      }
-    },
-    {
-      "name": "keywordsControl",
       "scope": [
-        "keyword.control.import",
-        "keyword.control.from",
-        "keyword.import"
+        "source.css.scss",
+        "source.css"
       ],
       "settings": {
-        "foreground": "#f06292"
+        "foreground": "#66dfc4"
       }
     },
     {
-      "name": "storageModifiers",
-      "scope": ["storage.modifier", "keyword.modifier", "storage.type"],
-      "settings": {
-        "foreground": "#f06292"
-      }
-    },
-    {
-      "name": "comments",
-      "scope": ["comment", "punctuation.definition.comment"],
-      "settings": {
-        "foreground": "#7F8286"
-      }
-    },
-    {
-      "name": "docComments",
-      "scope": ["comment.documentation", "comment.line.documentation"],
-      "settings": {
-        "foreground": "#7F8286"
-      }
-    },
-    {
-      "name": "numbers",
-      "scope": ["constant.numeric"],
-      "settings": {
-        "foreground": "#f7bc62"
-      }
-    },
-    {
-      "name": "booleans",
-      "scope": ["constant.language.boolean", "constant.language.json"],
-      "settings": {
-        "foreground": "#4fc3f7"
-      }
-    },
-    {
-      "name": "operators",
-      "scope": ["keyword.operator"],
-      "settings": {
-        "foreground": "#64b5f6"
-      }
-    },
-    {
-      "name": "macros",
-      "scope": ["entity.name.function.preprocessor", "meta.preprocessor"],
-      "settings": {
-        "foreground": "#64b5f6"
-      }
-    },
-    {
-      "name": "preprocessor",
-      "scope": ["meta.preprocessor"],
-      "settings": {
-        "foreground": "#4fc3f7"
-      }
-    },
-    {
-      "name": "urls",
-      "scope": ["markup.underline.link", "string.other.link.destination.mdx"],
-      "settings": {
-        "foreground": "#64b5f6"
-      }
-    },
-    {
-      "name": "tags",
-      "scope": ["entity.name.tag"],
-      "settings": {
-        "foreground": "#f06292"
-      }
-    },
-    {
-      "name": "jsxTags",
-      "scope": ["support.class.component"],
-      "settings": {
-        "foreground": "#64b5f6"
-      }
-    },
-    {
-      "name": "attributes",
-      "scope": ["entity.other.attribute-name", "meta.attribute"],
-      "settings": {
-        "foreground": "#f7bc62"
-      }
-    },
-    {
-      "name": "types",
-      "scope": ["support.type"],
-      "settings": {
-        "foreground": "#64b5f6"
-      }
-    },
-    {
-      "name": "constants",
-      "scope": ["variable.other.constant", "variable.readonly"],
-      "settings": {
-        "foreground": "#E3E1E1"
-      }
-    },
-    {
-      "name": "labels",
-      "scope": ["entity.name.label", "punctuation.definition.label"],
-      "settings": {
-        "foreground": "#4fc3f7"
-      }
-    },
-    {
-      "name": "namespaces",
       "scope": [
-        "entity.name.namespace",
-        "storage.modifier.namespace",
-        "markup.bold.markdown"
+        "entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#f7bc62"
+        "foreground": "#F7BC62"
       }
     },
     {
-      "name": "modules",
-      "scope": ["entity.name.module", "storage.modifier.module"],
-      "settings": {
-        "foreground": "#f06292"
-      }
-    },
-    {
-      "name": "typeParameters",
-      "scope": ["variable.type.parameter", "variable.parameter.type"],
-      "settings": {
-        "foreground": "#f7bc62"
-      }
-    },
-    {
-      "name": "exceptions",
-      "scope": ["keyword.control.exception", "keyword.control.trycatch"],
-      "settings": {
-        "foreground": "#4fc3f7"
-      }
-    },
-    {
-      "name": "decorators",
       "scope": [
-        "meta.decorator",
-        "punctuation.decorator",
-        "entity.name.function.decorator"
+        "support.function",
+        "support.variable.dom"
       ],
       "settings": {
-        "foreground": "#f7bc62"
+        "foreground": "#F7BC62"
       }
     },
     {
-      "name": "calls",
-      "scope": ["variable.function"],
+      "scope": "support.constant",
       "settings": {
-        "foreground": "#E3E1E1"
+        "foreground": "#4FC3F7"
       }
     },
     {
-      "name": "punctuation",
       "scope": [
-        "punctuation",
-        "punctuation.terminator",
-        "punctuation.definition.tag",
-        "punctuation.separator",
-        "punctuation.definition.string",
-        "punctuation.section.block"
+        "support.type"
       ],
       "settings": {
         "foreground": "#E3E1E1"
       }
     },
     {
-      "name": "yellow",
       "scope": [
-        "storage.type.numeric.go",
-        "storage.type.byte.go",
-        "storage.type.boolean.go",
-        "storage.type.string.go",
-        "storage.type.uintptr.go",
-        "storage.type.error.go",
-        "storage.type.rune.go",
-        "constant.language.go",
-        "support.class.dart",
-        "keyword.other.documentation",
-        "storage.modifier.import.java",
+        "support.class"
+      ],
+      "settings": {
+        "foreground": "#66dfc4"
+      }
+    },
+    {
+      "scope": "invalid",
+      "settings": {
+        "foreground": "#EF5350"
+      }
+    },
+    {
+      "scope": "invalid.deprecated",
+      "settings": {
+        "foreground": "#EF5350",
+        "background": "#664E4D"
+      }
+    },
+    {
+      "scope": "invalid.illegal",
+      "settings": {
+        "foreground": "#E3E1E1"
+      }
+    },
+    {
+      "scope": [
+        "meta.diff",
+        "meta.diff.header"
+      ],
+      "settings": {
+        "foreground": "#90A4AE"
+      }
+    },
+    {
+      "scope": "markup.deleted",
+      "settings": {
+        "foreground": "#EF5350"
+      }
+    },
+    {
+      "scope": "markup.inserted",
+      "settings": {
+        "foreground": "#AED581"
+      }
+    },
+    {
+      "scope": "markup.changed",
+      "settings": {
+        "foreground": "#F7BC62"
+      }
+    },
+    {
+      "scope": "constant.numeric.line-number.find-in-files - match",
+      "settings": {}
+    },
+    {
+      "scope": "entity.name.filename.find-in-files",
+      "settings": {
+        "foreground": "#FFD54F"
+      }
+    },
+    {
+      "scope": "keyword.other",
+      "settings": {
+        "foreground": "#B0BEC5"
+      }
+    },
+    {
+      "scope": [
+        "meta.property-value",
+        "support.constant.property-value",
+        "constant.other.color"
+      ],
+      "settings": {
+        "foreground": "#4FC3F7"
+      }
+    },
+    {
+      "scope": "meta.property-value punctuation.separator.key-value",
+      "settings": {
+        "foreground": "#E3E1E1"
+      }
+    },
+    {
+      "scope": [
+        "keyword.other.use",
+        "keyword.other.function.use",
+        "keyword.other.namespace",
+        "keyword.other.new",
+        "keyword.other.special-method",
+        "keyword.other.unit",
+        "keyword.other.use-as"
+      ],
+      "settings": {
+        "foreground": "#F06292"
+      }
+    },
+    {
+      "scope": [
+        "meta.use support.class.builtin",
+        "meta.other.inherited-class support.class.builtin"
+      ],
+      "settings": {
+        "foreground": "#F06292"
+      }
+    },
+    {
+      "scope": "variable.other",
+      "settings": {
+        "foreground": "#E3E1E1"
+      }
+    },
+    {
+      "scope": "meta.object-literal.key",
+      "settings": {
+        "foreground": "#F06292"
+      }
+    },
+    {
+      "scope": "variable.parameter.function.coffee",
+      "settings": {
+        "foreground": "#4FC3F7"
+      }
+    },
+    {
+      "scope": "markup.deleted.git_gutter",
+      "settings": {
+        "foreground": "#EF5350"
+      }
+    },
+    {
+      "scope": "markup.inserted.git_gutter",
+      "settings": {}
+    },
+    {
+      "scope": "markup.changed.git_gutter",
+      "settings": {
+        "foreground": "#F7BC62"
+      }
+    },
+    {
+      "scope": "meta.template.expression",
+      "settings": {
+        "foreground": "#4FC3F7"
+      }
+    },
+    {
+      "scope": [
+        "variable.other.constant.property",
+        "keyword.operator.ternary",
+        "keyword.operator.expression.typeof"
+      ],
+      "settings": {
+        "foreground": "#C972D8"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.type",
+        "support.type.python"
+      ],
+      "settings": {
+        "foreground": "#F7BC62"
+      }
+    },
+    {
+      "scope": "token.info-token",
+      "settings": {
+        "foreground": "#4FC3F7"
+      }
+    },
+    {
+      "scope": "token.warn-token",
+      "settings": {
+        "foreground": "#FFA726"
+      }
+    },
+    {
+      "scope": "token.error-token",
+      "settings": {
+        "foreground": "#EF5350"
+      }
+    },
+    {
+      "scope": "token.debug-token",
+      "settings": {
+        "foreground": "#BA68C8"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.tag.tsx",
+        "entity.name.tag.js.jsx",
+        "entity.name.tag.html",
+        "entity.name.tag.xml",
+        "entity.name.tag.script.html.vue",
+        "entity.name.tag.template.html.vue",
+        "entity.name.tag.style.html.vue",
+        "entity.name.tag.style.html.vue",
+        "entity.name.tag.script.html",
+        "entity.name.tag.template.html",
+        "entity.name.tag.style.html",
+        "entity.name.tag.block.any.html"
+      ],
+      "settings": {
+        "foreground": "#F06292"
+      }
+    },
+    {
+      "scope": [
+        "support.class.component.tsx",
+        "support.class.component.jsx"
+      ],
+      "settings": {
+        "foreground": "#64B5F6"
+      }
+    },
+    {
+      "scope": [
+        "support.type.primitive.tsx",
+        "support.type.primitive.ts"
+      ],
+      "settings": {
+        "foreground": "#4FC3F7"
+      }
+    },
+    {
+      "scope": "storage.modifier.tsx",
+      "settings": {
+        "foreground": "#F06292"
+      }
+    },
+    {
+      "scope": "entity.other.inherited-class.tsx",
+      "settings": {
+        "foreground": "#F7BC62"
+      }
+    },
+    {
+      "scope": "meta.object.member variable.other.readwrite.tsx",
+      "settings": {
+        "foreground": "#E3E1E1"
+      }
+    },
+    {
+      "scope": "meta.structure.dictionary.json string.quoted.double.json",
+      "settings": {
+        "foreground": "#E3E1E1"
+      }
+    },
+    {
+      "scope": "meta.structure.dictionary.value.json string.quoted.double.json",
+      "settings": {
+        "foreground": "#66dfc4"
+      }
+    },
+    {
+      "scope": [
+        "meta.structure.dictionary.json",
+        "punctuation.definition.string"
+      ],
+      "settings": {
+        "foreground": "#66dfc4"
+      }
+    },
+    {
+      "scope": [
+        "meta.structure.dictionary.json",
+        "support.type.property-name.json"
+      ],
+      "settings": {
+        "foreground": "#F06292"
+      }
+    },
+    {
+      "scope": [
         "punctuation.definition.list.begin.markdown",
+        "punctuation.definition.list.begin.mdx",
+        "punctuation.definition.list.end.markdown",
+        "punctuation.definition.list.end.mdx",
         "punctuation.definition.quote.begin.markdown",
+        "punctuation.definition.quote.begin.mdx",
+        "punctuation.definition.quote.end.markdown",
+        "punctuation.definition.quote.end.mdx",
         "meta.separator.markdown",
-        "entity.name.section.markdown",
-        "entity.name.section.mdx",
-        "string.other.number.mdx",
-        "variable.ordered.list.mdx",
-        "variable.unordered.list.mdx"
+        "meta.separator.mdx",
+        "markup.inline.raw.string.markdown",
+        "markup.raw.code.text.mdx"
       ],
       "settings": {
-        "foreground": "#f7bc62"
+        "foreground": "#F7BC62"
       }
     },
     {
-      "name": "green",
-      "scope": [],
-      "settings": {
-        "foreground": "#66dfc4"
-      }
-    },
-    {
-      "name": "cyan",
       "scope": [
-        "markup.italic.markdown",
-        "support.type.python",
-        "variable.legacy.builtin.python",
-        "support.constant.property-value.css",
-        "storage.modifier.attribute.swift"
+        "entity.name.section.markdown",
+        "entity.name.section.mdx"
       ],
       "settings": {
-        "foreground": "#4fc3f7"
+        "foreground": "#64B5F6"
       }
     },
     {
-      "name": "blue",
-      "scope": [],
-      "settings": {
-        "foreground": "#64b5f6"
-      }
-    },
-    {
-      "name": "purple",
-      "scope": ["keyword.channel.go", "keyword.other.platform.os.swift"],
-      "settings": {
-        "foreground": "#d88ee4"
-      }
-    },
-    {
-      "name": "magenta",
       "scope": [
         "punctuation.definition.heading.markdown",
         "punctuation.definition.heading.mdx"
       ],
       "settings": {
-        "foreground": "#f06292"
+        "foreground": "#F06292"
       }
     },
     {
-      "name": "red",
-      "scope": [],
+      "scope": [
+        "markup.raw.inline.markdown",
+        "markup.raw.inline.mdx"
+      ],
       "settings": {
-        "foreground": "#f06292"
+        "foreground": "#4FC3F7"
       }
     },
     {
-      "name": "orange",
-      "scope": [],
+      "scope": [
+        "punctuation.definition.bold.markdown",
+        "punctuation.definition.bold.mdx",
+        "punctuation.definition.italic.markdown",
+        "punctuation.definition.italic.mdx",
+        "punctuation.definition.entity"
+      ],
       "settings": {
-        "foreground": "#f4a343"
+        "foreground": "#F06292"
+      }
+    },
+    {
+      "scope": [
+        "punctuation.definition.string.begin.markdown",
+        "punctuation.definition.string.begin.mdx",
+        "punctuation.definition.string.end.markdown",
+        "punctuation.definition.string.end.mdx"
+      ],
+      "settings": {
+        "foreground": "#F06292"
+      }
+    },
+    {
+      "scope": [
+        "punctuation.definition.metadata.markdown",
+        "punctuation.definition.metadata.mdx"
+      ],
+      "settings": {
+        "foreground": "#F06292"
+      }
+    },
+    {
+      "scope": [
+        "markup.underline.link.markdown",
+        "markup.underline.link.image.markdown",
+        "string.other.link.destination.mdx",
+        "meta.image.inline.markdown",
+        "meta.image.inline.mdx"
+      ],
+      "settings": {
+        "foreground": "#F06292"
+      }
+    },
+    {
+      "scope": [
+        "markup.bold.markdown",
+        "string.other.strong.asterisk.mdx",
+        "markup.italic.markdown",
+        "markup.italic.mdx"
+      ],
+      "settings": {
+        "foreground": "#F06292"
+      }
+    },
+    {
+      "scope": [
+        "markup.italic.markdown",
+        "markup.italic.mdx"
+      ],
+      "settings": {}
+    },
+    {
+      "scope": [
+        "markup.bold.markdown",
+        "markup.bold.mdx"
+      ],
+      "settings": {}
+    },
+    {
+      "scope": [
+        "markup.raw.block.markdown",
+        "markup.raw.block.mdx"
+      ],
+      "settings": {
+        "foreground": "#4FC3F7"
+      }
+    },
+    {
+      "scope": "keyword.other.rust",
+      "settings": {
+        "foreground": "#C972D8"
+      }
+    },
+    {
+      "scope": "keyword.other.fn.rust",
+      "settings": {
+        "foreground": "#F06292"
+      }
+    },
+    {
+      "name": "PHP: Begin block",
+      "scope": [
+        "punctuation.section.embedded.begin.php",
+        "keyword.other.class.php"
+      ],
+      "settings": {
+        "foreground": "#F06292"
+      }
+    },
+    {
+      "name": "PHP: Class name",
+      "scope": [
+        "support.class.php"
+      ],
+      "settings": {
+        "foreground": "#E3E1E1"
+      }
+    },
+    {
+      "name": "PHP: Meta use",
+      "scope": [
+        "meta.use.php"
+      ],
+      "settings": {
+        "foreground": "#66dfc4"
+      }
+    },
+    {
+      "scope": "keyword.other.definition.ini",
+      "settings": {
+        "foreground": "#64B5F6"
+      }
+    },
+    {
+      "name": "Prisma: Primitive",
+      "scope": "support.type.primitive.prisma",
+      "settings": {
+        "foreground": "#F7BC62"
+      }
+    },
+    {
+      "name": "Prisma: Constant",
+      "scope": "support.constant.constant.prisma",
+      "settings": {
+        "foreground": "#F06292"
+      }
+    },
+    {
+      "name": "Prisma: Relation",
+      "scope": "variable.language.relations.prisma",
+      "settings": {
+        "foreground": "#66dfc4"
+      }
+    },
+    {
+      "scope": "entity.name.tag.yaml",
+      "settings": {
+        "foreground": "#F06292"
+      }
+    },
+    {
+      "scope": "storage.type.java",
+      "settings": {
+        "foreground": "#F7BC62",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": [
+        "keyword.other.package.java",
+        "keyword.other.import.java"
+      ],
+      "settings": {
+        "foreground": "#F06292",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": "storage.modifier.package.java",
+      "settings": {
+        "foreground": "#F7BC62"
+      }
+    },
+    {
+      "scope": "storage.modifier.import.java",
+      "settings": {
+        "foreground": "#E3E1E1"
+      }
+    },
+    {
+      "scope": "punctuation.separator.java",
+      "settings": {
+        "foreground": "#F5F5F5"
+      }
+    },
+    {
+      "scope": "meta.tag.xml",
+      "settings": {
+        "foreground": "#4FC3F7"
+      }
+    },
+    {
+      "scope": [
+        "keyword.other.declaration-specifier.swift",
+        "keyword.other.declaration-specifier.accessibility.swift"
+      ],
+      "settings": {
+        "foreground": "#F06292",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": [
+        "support.type.swift",
+        "meta.function-result.swift",
+        "variable.language.swift",
+        "keyword.operator.custom.infix.swift"
+      ],
+      "settings": {
+        "foreground": "#64B5F6"
+      }
+    },
+    {
+      "scope": "variable.parameter.function.swift",
+      "settings": {
+        "foreground": "#E3E1E1"
+      }
+    },
+    {
+      "scope": "entity.name.function.swift",
+      "settings": {
+        "foreground": "#64B5F6",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": [
+        "variable.parameter.function.swift",
+        "meta.parameter-clause.swift"
+      ],
+      "settings": {
+        "foreground": "#E3E1E1"
+      }
+    },
+    {
+      "scope": [
+        "support.function.go"
+      ],
+      "settings": {
+        "foreground": "#4FC3F7",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": [
+        "keyword.operator.address.go",
+        "keyword.operator.pointer.go"
+      ],
+      "settings": {
+        "foreground": "#64B5F6"
+      }
+    },
+    {
+      "scope": [
+        "keyword.channel.go"
+      ],
+      "settings": {
+        "foreground": "#C972D8"
+      }
+    },
+    {
+      "scope": [
+        "storage.type.numeric.go",
+        "storage.type.string.go",
+        "storage.type.error.go",
+        "storage.type.boolean.go",
+        "storage.type.byte.go",
+        "storage.type.uintptr.go",
+        "storage.type.error.go",
+        "storage.type.rune.go",
+        "storage.type.complex.go"
+      ],
+      "settings": {
+        "foreground": "#F7BC62"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.tag.astro"
+      ],
+      "settings": {
+        "foreground": "#F06292"
+      }
+    },
+    {
+      "scope": [
+        "support.class.component.astro"
+      ],
+      "settings": {
+        "foreground": "#64B5F6"
       }
     }
   ]


### PR DESCRIPTION
Addresses #70: Added C++-specific scopes to one-hunter.ts, including variable.cpp with cyanBase (#4fc3f7) for better readability. Tested on VSCode 1.103.0 (macOS). Build regenerates JSON files, affecting multiple themes, but the fix is intentional. Added demos/cpp.cpp as a test file.

The grayed out variable names now appear in white.

<img width="822" height="803" alt="Screenshot 2025-08-12 at 1 15 41 AM" src="https://github.com/user-attachments/assets/92d6d4a2-7748-4210-a6e4-6cf23df5f477" />

@Railly 